### PR TITLE
CodeQL: Set Go version to match one specified in go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # Use Go version that is required by the project
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3


### PR DESCRIPTION
Fixes following warning:

>   * Version `v1.20.14` of Go is installed, but this is lower than `v1.21` required by your project's `go.mod`. [Install a newer version of Go before analyzing your project](https://github.com/actions/setup-go#basic).