### PR TITLE
Config: Add TCs for empty destination directory

### DIFF
--- a/handlers/configuration_handler_update_functions_test.go
+++ b/handlers/configuration_handler_update_functions_test.go
@@ -90,6 +90,17 @@ func (h *HandlersTestSuite) TestUpdateTarredConfig() {
 				"common dif": Modified,
 				"old":        Deleted,
 			}},
+		{name: "when old dir is empty and no errors occurred",
+			newConfigFiles: []string{"new", "other", "third"},
+			oldConfigFiles: []string{},
+			events: []event{{configFile: "new", move: true},
+				{configFile: "other", move: true},
+				{configFile: "third", move: true}},
+			expectedChangedFiles: map[string]Modification{
+				"new":   Created,
+				"other": Created,
+				"third": Created,
+			}},
 	}
 	for _, test := range testCases {
 		test := test

--- a/handlers/internal/filesystem/file_system_test.go
+++ b/handlers/internal/filesystem/file_system_test.go
@@ -204,4 +204,9 @@ func (f *filesystemTestSuite) TestListFileNamesInDir() {
 		f.NoError(err)
 		f.ElementsMatch(files, expectedFiles)
 	})
+	f.RunWithTestDir("when an empty directory exists", func(testDir string) {
+		files, err := f.ListFileNamesInDir(testDir)
+		f.NoError(err)
+		f.Empty(files)
+	})
 }


### PR DESCRIPTION
Add test cases to ensure that TarredConfigurationHandler will work when destination configuration directory is empty.